### PR TITLE
Unreleased Pokemon uIDFill

### DIFF
--- a/src/com/podevs/android/poAndroid/pokeinfo/PokemonInfo.java
+++ b/src/com/podevs/android/poAndroid/pokeinfo/PokemonInfo.java
@@ -413,12 +413,7 @@ public class PokemonInfo {
 					curIndex = nextIndex+1;
 				}
 
-				try {
-					pokemons[gen].get(i).stats = stats;
-				} catch (Exception e) {
-					int q = i;
-					int r = q;
-				}
+				pokemons[gen].get(i).stats = stats;
 			}
 		});
 	}


### PR DESCRIPTION
"pokemons" array was filled with keys using "released.txt" and so Pokemon like Mimikyu-Broken wouldn't exist and crash the client later when it tried to look for them. 