### PR TITLE
Hidden power fixes in teambuilder

### DIFF
--- a/src/com/podevs/android/poAndroid/pokeinfo/HiddenPowerInfo.java
+++ b/src/com/podevs/android/poAndroid/pokeinfo/HiddenPowerInfo.java
@@ -63,6 +63,26 @@ public class HiddenPowerInfo {
 		return hiddenPowerConfigurations[(gen.num > 2 ? 1 : 0)][type];
 	}
 
+	static public byte [][] possibilitiesForType(final int type, Gen gen) {
+		byte[][] ret = new byte[0][];
+		int size = 0;
+
+		for (int i = 63; i >= 0; i--) {
+			int gt = Type(gen, i & 1, (i & 2)/2, (i & 4)/4, (i & 8)/8, (i & 16)/16, (i & 32)/32);
+			if (gt == type) {
+				byte [][] temp = ret.clone();
+				ret = new byte[size+1][];
+				for (int j = 0; j < temp.length; j++) {
+					ret[j] = temp[j];
+				}
+				ret[size] = new byte[] {(byte)((i&1)+30), (byte)(((i & 2)/2)+30), (byte)(((i & 4)/4)+30), (byte)(((i & 8)/8)+30), (byte)(((i & 16)/16)+30), (byte)(((i & 32)/32)+30)};
+				size++;
+			}
+		}
+
+		return ret;
+	}
+
 	private static int floor(int i) {
 		return (int) Math.floor((double) i);
 	}

--- a/src/com/podevs/android/poAndroid/teambuilder/MoveChooserFragment.java
+++ b/src/com/podevs/android/poAndroid/teambuilder/MoveChooserFragment.java
@@ -12,10 +12,7 @@ import android.widget.*;
 import android.widget.AdapterView.OnItemClickListener;
 import com.podevs.android.poAndroid.R;
 import com.podevs.android.poAndroid.poke.TeamPoke;
-import com.podevs.android.poAndroid.pokeinfo.HiddenPowerInfo;
-import com.podevs.android.poAndroid.pokeinfo.MoveInfo;
-import com.podevs.android.poAndroid.pokeinfo.PokemonInfo;
-import com.podevs.android.poAndroid.pokeinfo.GenInfo;
+import com.podevs.android.poAndroid.pokeinfo.*;
 
 import java.util.ArrayList;
 
@@ -111,8 +108,27 @@ public class MoveChooserFragment extends Fragment {
 				public void onClick(DialogInterface dialog, int which) {
 					ListView lw = ((AlertDialog)dialog).getListView();
 					int type = lw.getCheckedItemPosition() + 1;
-					if (poke().gen().num < 7) {
-						byte[] config = HiddenPowerInfo.configurationForType(type, poke().gen);
+					if (!poke().isHackmon && type == 1 && ((poke().uID().pokeNum >= 716 && poke().uID().pokeNum <= 721) || (poke().uID().pokeNum >= 785 && poke().uID().pokeNum <= 802))) {
+						poke().removeMove(237);
+
+						final AlertDialog.Builder errorMsg = new AlertDialog.Builder(getActivity());
+						errorMsg.setTitle("Invalid hidden power type")
+								.setMessage(PokemonInfo.name(poke().uID) + " cannot have hidden power Fighting.")
+								.setPositiveButton("Okay", new OnClickListener() {
+									public void onClick(DialogInterface dialog, int which) {
+
+									}
+								});
+						errorMsg.create().show();
+					}
+					else if (poke().gen().num < 7) {
+						byte[] config;
+						if (!poke().isHackmon && (type == 2 || type == 3 || type == 5) && ((poke().uID().pokeNum >= 716 && poke().uID().pokeNum <= 721) || (poke().uID().pokeNum >= 785 && poke().uID().pokeNum <= 802))) {
+							config = HiddenPowerInfo.possibilitiesForType(type, poke().gen)[1];
+						}
+						else {
+							config = HiddenPowerInfo.configurationForType(type, poke().gen);
+						}
 						if (config != null) {
 							poke().DVs = config;
 						}


### PR DESCRIPTION
Prevents gen 6/7 legends from setting hp fighting in teambuilder and gives them 3 31 ivs for flying/poison/rock.